### PR TITLE
SafeChildWatcher implementation.

### DIFF
--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -422,3 +422,6 @@ class GLibEventLoopPolicy(events.AbstractEventLoopPolicy):
             context=GLib.main_context_default(), application=self._application)
         l._policy = self
         return l
+
+    def set_child_watcher(self, watcher):
+        pass

--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -7,7 +7,7 @@ from asyncio import events, tasks, unix_events
 
 from gi.repository import GLib, Gio
 
-__all__ = ['GLibEventLoop', 'GLibEventLoopPolicy']
+__all__ = ['GLibEventLoop', 'GLibEventLoopPolicy', 'GLibChildWatcher']
 
 
 class GLibChildWatcher(unix_events.AbstractChildWatcher):

--- a/gbulb/utils.py
+++ b/gbulb/utils.py
@@ -24,6 +24,9 @@ def install(gtk=False):
 
     asyncio.set_event_loop_policy(policy)
 
+    from .glib_events import GLibChildWatcher
+    asyncio.SafeChildWatcher = GLibChildWatcher
+
 
 def get_event_loop():
     """Alias to asyncio.get_event_loop()."""


### PR DESCRIPTION
This branch implements SafeChildWatcher by using GLibSafeChildWatcher.

I'm not convinced this is the best approach (globally replacing SafeChildWatcher with GLibSafeChildWatcher), so this PR is to open a conversation about a correct implementation.